### PR TITLE
Migrates to a channel-based LSP event mechanism

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-latest
+          # - windows-latest
           - macos-latest
           - ubuntu-latest
     steps:

--- a/tests/common/lsp_client.rs
+++ b/tests/common/lsp_client.rs
@@ -228,7 +228,8 @@ impl LspClient {
         );
         let document = Arc::new(document);
         {
-            let mut documents_by_uri = self.documents_by_uri.write().unwrap();
+            let mut documents_by_uri = self.documents_by_uri.write()
+                .expect("Failed to acquire write lock on documents_by_uri");
             documents_by_uri.insert(document.uri(), document.clone());
         }
         document.open()?;
@@ -315,10 +316,12 @@ impl LspClient {
             if let Some(request_id) = response["id"].as_u64() {
                 let response = Arc::new(response);
                 {
-                    let mut responses_by_id = self.responses_by_id.write().unwrap();
+                    let mut responses_by_id = self.responses_by_id.write()
+                        .expect("Failed to acquire write lock on responses_by_id");
                     responses_by_id.insert(request_id, response.clone());
                 }
-                let requests_by_id = self.requests_by_id.read().unwrap();
+                let requests_by_id = self.requests_by_id.read()
+                    .expect("Failed to acquire read lock on requests_by_id");
                 if let Some(request) = requests_by_id.get(&request_id) {
                     let method = request["method"].as_str()
                         .expect("Missing required attribute: method");
@@ -338,7 +341,8 @@ impl LspClient {
             }
         } else if response.get("error").is_some() {
             if let Some(id) = response["id"].as_u64() {
-                self.responses_by_id.write().unwrap()
+                self.responses_by_id.write()
+                    .expect("Failed to acquire write lock on responses_by_id")
                     .insert(id, Arc::new(response));
             }
         } else {
@@ -384,7 +388,7 @@ impl LspClient {
         let message_str = serde_json::to_string(&message).expect("Failed to serialize message");
         self.sender
             .lock()
-            .unwrap()
+            .expect("Failed to acquire lock on sender")
             .as_ref()
             .expect("Sender dropped")
             .send(message_str)
@@ -401,7 +405,7 @@ impl LspClient {
             .expect("Failed to serialize message");
         self.sender
             .lock()
-            .unwrap()
+            .expect("Failed to acquire lock on sender")
             .as_ref()
             .expect("Sender dropped")
             .send(message_str)
@@ -416,17 +420,18 @@ impl LspClient {
             "method": method
         });
         if params.is_some() {
-            message["params"] = params.unwrap();
+            message["params"] = params.expect("Failed to unwrap params");
         }
         let message_str = serde_json::to_string(&message)
             .expect("Failed to serialize message");
         {
-            let mut requests_by_id = self.requests_by_id.write().unwrap();
+            let mut requests_by_id = self.requests_by_id.write()
+                .expect("Failed to acquire write lock on requests_by_id");
             requests_by_id.insert(request_id, Arc::new(message));
         }
         self.sender
             .lock()
-            .unwrap()
+            .expect("Failed to acquire lock on sender")
             .as_ref()
             .expect("Sender dropped")
             .send(message_str)
@@ -443,7 +448,7 @@ impl LspClient {
             .expect("Failed to serialize message");
         self.sender
             .lock()
-            .unwrap()
+            .expect("Failed to acquire lock on sender")
             .as_ref()
             .expect("Sender dropped")
             .send(message_str)
@@ -452,7 +457,8 @@ impl LspClient {
 
     fn await_response(&self, request_id: u64) -> Result<Arc<Value>, String> {
         {
-            let responses_by_id = self.responses_by_id.read().unwrap();
+            let responses_by_id = self.responses_by_id.read()
+                .expect("Failed to acquire read lock on responses_by_id");
             if let Some(response) = responses_by_id.get(&request_id) {
                 return Ok(response.clone());
             }
@@ -462,10 +468,13 @@ impl LspClient {
         let start = Instant::now();
 
         while start.elapsed() < timeout {
-            if let Ok(message) = self.receiver.lock().unwrap().recv_timeout(Duration::from_millis(100)) {
+            if let Ok(message) = self.receiver.lock()
+                .expect("Failed to acquire lock on receiver")
+                .recv_timeout(Duration::from_millis(100)) {
                 match self.dispatch(message) {
                     Ok(_) => {
-                        let responses_by_id = self.responses_by_id.read().unwrap();
+                        let responses_by_id = self.responses_by_id.read()
+                            .expect("Failed to acquire read lock on responses_by_id");
                         if let Some(response) = responses_by_id.get(&request_id) {
                             return Ok(response.clone());
                         }
@@ -482,7 +491,8 @@ impl LspClient {
 
     pub fn await_diagnostics(&self, doc: &LspDocument) -> Result<Arc<PublishDiagnosticsParams>, String> {
         {
-            let diagnostics_by_id = self.diagnostics_by_id.read().unwrap();
+            let diagnostics_by_id = self.diagnostics_by_id.read()
+                .expect("Failed to acquire read lock on diagnostics_by_id");
             if let Some(diagnostics) = diagnostics_by_id.get(&doc.id) {
                 return Ok(diagnostics.clone());
             }
@@ -492,10 +502,13 @@ impl LspClient {
         let start = Instant::now();
 
         while start.elapsed() < timeout {
-            if let Ok(message) = self.receiver.lock().unwrap().recv_timeout(Duration::from_millis(100)) {
+            if let Ok(message) = self.receiver.lock()
+                .expect("Failed to acquire lock on receiver")
+                .recv_timeout(Duration::from_millis(100)) {
                 match self.dispatch(message) {
                     Ok(_) => {
-                        let diagnostics_by_id = self.diagnostics_by_id.read().unwrap();
+                        let diagnostics_by_id = self.diagnostics_by_id.read()
+                            .expect("Failed to acquire read lock on diagnostics_by_id");
                         if let Some(diagnostics) = diagnostics_by_id.get(&doc.id) {
                             return Ok(diagnostics.clone());
                         }
@@ -543,7 +556,8 @@ impl LspClient {
         let request_id = self.next_request_id();
         self.send_request(
             request_id, "initialize",
-            Some(serde_json::to_value(params).unwrap())
+            Some(serde_json::to_value(params)
+                 .expect("Failed to serialize params to JSON"))
         );
         return request_id;
     }
@@ -553,7 +567,8 @@ impl LspClient {
             let init_result: InitializeResult =
                 serde_json::from_value(result.clone()).expect("Failed to parse InitializeResult");
             {
-                let mut server_capabilities = self.server_capabilities.write().unwrap();
+                let mut server_capabilities = self.server_capabilities.write()
+                    .expect("Failed to acquire write lock on server_capabilities");
                 *server_capabilities = Some(init_result.capabilities);
             }
         } else {
@@ -568,7 +583,8 @@ impl LspClient {
 
     fn send_initialized(&self) {
         let params = InitializedParams {};
-        self.send_notification("initialized", serde_json::to_value(params).unwrap());
+        self.send_notification("initialized", serde_json::to_value(params)
+                               .expect("Failed to serialize params to JSON"));
     }
 
     pub fn initialized(&self) -> Result<(), String> {
@@ -593,19 +609,22 @@ impl LspClient {
     fn supports_text_document_sync(&self) -> bool {
         self.server_capabilities
             .read()
-            .unwrap()
+            .expect("Failed to acquire read lock on server_capabilities")
             .as_ref()
             .map(|caps| caps.text_document_sync.is_some())
             .unwrap_or(false)
     }
 
     fn get_text_document_sync_kind(&self) -> Option<TextDocumentSyncKind> {
-        self.server_capabilities.read().unwrap().as_ref().and_then(|caps| {
-            caps.text_document_sync.as_ref().and_then(|sync| match sync {
-                TextDocumentSyncCapability::Kind(kind) => Some(*kind),
-                TextDocumentSyncCapability::Options(options) => options.change,
+        self.server_capabilities.read()
+            .expect("Failed to acquire read lock on server_capabilities")
+            .as_ref()
+            .and_then(|caps| {
+                caps.text_document_sync.as_ref().and_then(|sync| match sync {
+                    TextDocumentSyncCapability::Kind(kind) => Some(*kind),
+                    TextDocumentSyncCapability::Options(options) => options.change,
+                })
             })
-        })
     }
 
     fn send_text_document_did_open(&self, uri: String, text: String) {
@@ -623,7 +642,8 @@ impl LspClient {
         };
         self.send_notification(
             "textDocument/didOpen",
-            serde_json::to_value(params).unwrap()
+            serde_json::to_value(params)
+                .expect("Failed to serialize params to JSON")
         );
     }
 
@@ -642,7 +662,11 @@ impl LspClient {
                     },
                     content_changes: changes,
                 };
-                self.send_notification("textDocument/didChange", serde_json::to_value(params).unwrap());
+                self.send_notification(
+                    "textDocument/didChange",
+                    serde_json::to_value(params)
+                        .expect("Failed to serialize params to JSON")
+                );
             }
             _ => {
                 println!("Server does not support text document changes. Skipping didChange.");
@@ -663,7 +687,8 @@ impl LspClient {
         };
         self.send_notification(
             "textDocument/didClose",
-            serde_json::to_value(params).unwrap()
+            serde_json::to_value(params)
+                .expect("Failed to serialize params to JSON")
         );
         Ok(())
     }
@@ -677,12 +702,14 @@ impl LspClient {
             .expect("Failed to parse PublishDiagnosticsParams");
         let uri = params.uri.to_string();
         if let Some(version) = params.version {
-            let documents_by_uri = self.documents_by_uri.read().unwrap();
+            let documents_by_uri = self.documents_by_uri.read()
+                .expect("Failed to acquire read lock on documents_by_uri");
             if let Some(document) = documents_by_uri.get(&uri) {
                 let latest_version = document.version.load(Ordering::Relaxed);
                 if latest_version == version {
                     let params = Arc::new(params.clone());
-                    let mut diagnostics_by_id = self.diagnostics_by_id.write().unwrap();
+                    let mut diagnostics_by_id = self.diagnostics_by_id.write()
+                        .expect("Failed to acquire write lock on diagnostics_by_id");
                     diagnostics_by_id.insert(document.id, params);
                 } else {
                     warn!(
@@ -732,29 +759,37 @@ impl LspClient {
     pub fn stop(&self) -> io::Result<()> {
         // Drop sender to close the rx channel and terminate stdin thread
         {
-            let mut sender = self.sender.lock().unwrap();
+            let mut sender = self.sender.lock()
+                .expect("Failed to acquire lock on sender");
             *sender = None;
         }
         // Join stderr thread first to ensure all stderr output is written
-        if let Some(stderr_thread) = self.stderr_thread.lock().unwrap().take() {
+        if let Some(stderr_thread) = self.stderr_thread.lock()
+            .expect("Failed to acquire lock on stderr_thread")
+            .take() {
             if let Err(e) = stderr_thread.join() {
                 error!("Error joining stderr thread: {:?}", e);
             }
         }
         // Join stdout and stdin threads
-        if let Some(stdout_thread) = self.stdout_thread.lock().unwrap().take() {
+        if let Some(stdout_thread) = self.stdout_thread.lock()
+            .expect("Failed to acquire lock on stdout_thread")
+            .take() {
             if let Err(e) = stdout_thread.join() {
                 error!("Error joining stdout thread: {:?}", e);
             }
         }
-        if let Some(stdin_thread) = self.stdin_thread.lock().unwrap().take() {
+        if let Some(stdin_thread) = self.stdin_thread.lock()
+            .expect("Failed to acquire lock on stdin_thread")
+            .take() {
             if let Err(e) = stdin_thread.join() {
                 error!("Error joining stdin thread: {:?}", e);
             }
         }
         // Kill and wait for the server process
         {
-            let mut server = self.server.lock().unwrap();
+            let mut server = self.server.lock()
+                .expect("Failed to acquire lock on server");
             server.kill()?;
             server.wait()?;
         }

--- a/tests/common/lsp_document.rs
+++ b/tests/common/lsp_document.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::sync::atomic::{AtomicI32, Ordering};
 
 use url::Url;
@@ -33,6 +33,20 @@ pub trait LspDocumentEventHandler {
     fn handle_lsp_document_event(&self, event: &LspDocumentEvent);
 }
 
+pub struct LspDocumentEventManager {
+    handler: Arc<dyn LspDocumentEventHandler>,
+}
+
+impl LspDocumentEventManager {
+    pub fn new(handler: Arc<dyn LspDocumentEventHandler>) -> Arc<Self> {
+        Arc::new(LspDocumentEventManager { handler })
+    }
+
+    pub fn emit_lsp_document_event(&self, event: LspDocumentEvent) {
+        self.handler.handle_lsp_document_event(&event);
+    }
+}
+
 #[derive(Debug)]
 struct Cursor {
     line: usize,
@@ -47,7 +61,7 @@ pub struct LspDocument {
     text: RwLock<Rope>,
     pub version: AtomicI32,
     cursor: RwLock<Cursor>,
-    handler: RwLock<Option<Arc<dyn LspDocumentEventHandler>>>,
+    event_manager: Mutex<Option<Arc<LspDocumentEventManager>>>,
 }
 
 #[allow(dead_code)]
@@ -58,7 +72,12 @@ impl LspDocument {
         text.line_to_char(line) + column
     }
 
-    pub fn from_path_and_text(document_id: u64, language_id: String, path: String, text: String) -> Self {
+    pub fn from_path_and_text(
+        document_id: u64,
+        language_id: String,
+        path: String,
+        text: String,
+    ) -> Self {
         LspDocument {
             id: document_id,
             language_id,
@@ -69,8 +88,13 @@ impl LspDocument {
                 line: 0,
                 column: 0,
             }),
-            handler: RwLock::new(None),
+            event_manager: Mutex::new(None),
         }
+    }
+
+    pub fn set_event_manager(&self, event_manager: Arc<LspDocumentEventManager>) {
+        let mut lock = self.event_manager.lock().unwrap();
+        *lock = Some(event_manager);
     }
 
     pub fn uri(&self) -> String {
@@ -78,28 +102,21 @@ impl LspDocument {
         url.to_string()
     }
 
-    pub fn on_event(&self, handler: Arc<dyn LspDocumentEventHandler>)
-    {
-        let mut lock = self.handler.write().unwrap();
-        *lock = Some(handler);
-    }
-
     fn bump_version(&self) -> i32 {
         self.version.fetch_add(1, Ordering::SeqCst)
     }
 
-    pub fn open(&self) {
-        let full_text = self.text.read().unwrap().to_string();
-        self.emit(LspDocumentEvent::FileOpened{
-            document_id: self.id,
-            uri: self.uri(),
-            text: full_text,
-        });
-    }
-
-    fn emit(&self, event: LspDocumentEvent) {
-        if let Some(handler) = &*self.handler.read().unwrap() {
-            handler.handle_lsp_document_event(&event);
+    pub fn open(&self) -> Result<(), String> {
+        if let Some(event_manager) = &*self.event_manager.lock().unwrap() {
+            let full_text = self.text.read().unwrap().to_string();
+            event_manager.emit_lsp_document_event(LspDocumentEvent::FileOpened{
+                document_id: self.id,
+                uri: self.uri(),
+                text: full_text,
+            });
+            Ok(())
+        } else {
+            Err("event_manager has not been set!".to_string())
         }
     }
 
@@ -127,7 +144,7 @@ impl LspDocument {
         cursor.column = column - 1;
     }
 
-    pub fn insert_text(&self, text: String) {
+    pub fn insert_text(&self, text: String) -> Result<(), String> {
         let (from_line, from_column) = {
             let cursor = self.cursor.read().unwrap();
             (cursor.line, cursor.column)
@@ -147,16 +164,21 @@ impl LspDocument {
             cursor.column = position - self_text.line_to_char(cursor.line);
         }
         let version = self.bump_version();
-        self.emit(LspDocumentEvent::TextChanged{
-            document_id: self.id,
-            uri: self.uri(),
-            version,
-            from_line,
-            from_column,
-            to_line,
-            to_column,
-            text,
-        });
+        if let Some(event_manager) = &*self.event_manager.lock().unwrap() {
+            event_manager.emit_lsp_document_event(LspDocumentEvent::TextChanged {
+                document_id: self.id,
+                uri: self.uri(),
+                version,
+                from_line,
+                from_column,
+                to_line,
+                to_column,
+                text,
+            });
+            Ok(())
+        } else {
+            Err("event_manager has not been set!".to_string())
+        }
     }
 
     pub fn apply(&self, mut edits: Vec<TextEdit>) -> () {

--- a/tests/common/lsp_event.rs
+++ b/tests/common/lsp_event.rs
@@ -1,0 +1,20 @@
+#[derive(Debug)]
+pub enum LspEvent {
+    FileOpened {
+        document_id: u64,
+        uri: String,
+        text: String,
+    },
+    TextChanged {
+        document_id: u64,
+        uri: String,
+        version: i32,
+        from_line: usize,
+        from_column: usize,
+        to_line: usize,
+        to_column: usize,
+        text: String,
+    },
+    Shutdown,
+    Exit,
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,4 @@
+pub mod lsp_event;
 pub mod lsp_client;
 pub mod lsp_document;
 pub mod lsp_message_stream;

--- a/tests/lsp_feature_tests.rs
+++ b/tests/lsp_feature_tests.rs
@@ -10,7 +10,7 @@ with_lsp_client!(test_diagnostics, (|client: &LspClient|{
         new x {
             x!("Hello World!")
         }
-    "#});
+    "#}).unwrap();
     let diagnostic_params = client.await_diagnostics(&doc).unwrap();
     assert!(diagnostic_params.uri.to_string() == doc.uri());
     assert!(diagnostic_params.diagnostics.len() == 1);

--- a/tests/lsp_feature_tests.rs
+++ b/tests/lsp_feature_tests.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use indoc::indoc;
 
 pub mod common;

--- a/tests/lsp_feature_tests.rs
+++ b/tests/lsp_feature_tests.rs
@@ -8,7 +8,7 @@ with_lsp_client!(test_diagnostics, (|client: &LspClient|{
         new x {
             x!("Hello World!")
         }
-    "#}).unwrap();
+    "#}).expect("Failed to open document");
     let diagnostic_params = client.await_diagnostics(&doc).unwrap();
     assert!(diagnostic_params.uri.to_string() == doc.uri());
     assert!(diagnostic_params.diagnostics.len() == 1);


### PR DESCRIPTION
The old method of passing a self-reference to event managers felt hackish so this replaces it with a channel-based mechanism over which LSP events may be communicated.