### PR TITLE
Updates test for new Lsp internal API

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -179,7 +179,7 @@ jobs:
           ~/.ivy2/cache
           ~/.sbt
           f1r3fly/node/target/universal/stage/
-        key: ${{ runner.os }}-rnode-${{ steps.dep-hash.outputs.hash }}
+        key: ${{ runner.os }}-rnode-${{ steps.rnode-hash.outputs.hash }}
     - name: Clone F1R3FLY repository
       if: steps.cache-rnode.outputs.cache-hit != 'true'
       run: |

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("proto/repl.proto")?;
+    tonic_build::compile_protos("proto/lsp.proto")?;
     Ok(())
 }

--- a/proto/lsp.proto
+++ b/proto/lsp.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+package lsp;
+
+// If you are building for other languages "scalapb.proto"
+// can be manually obtained here:
+// https://raw.githubusercontent.com/scalapb/ScalaPB/master/protobuf/scalapb/scalapb.proto
+// make a scalapb directory in this file's location and place it inside
+
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+    package_name: "coop.rchain.node.model"
+};
+
+service Lsp {
+    rpc Validate (ValidateRequest) returns (ValidateResponse) {}
+}
+
+message ValidateRequest {
+    string text = 1;
+}
+
+message ValidateResponse {
+    string message = 1;
+}


### PR DESCRIPTION
Changes:
- Updates test for new Lsp internal API
- BUGFIX: Only breaks the event loop on exit to avoid race condition when exit event is sent after the channel is closed

Notes:
1. Depends on: https://github.com/F1R3FLY-io/f1r3fly/pull/41
2. CI will not succeed until (1.) is merged.